### PR TITLE
enable -fstack-usage to enable tools such as puncover

### DIFF
--- a/wscript
+++ b/wscript
@@ -45,6 +45,7 @@ def build(ctx):
     for p in ctx.env.TARGET_PLATFORMS:
         ctx.set_env(ctx.all_envs[p])
         ctx.set_group(ctx.env.PLATFORM_NAME)
+        ctx.env.CFLAGS += ["-fstack-usage"]
         app_elf='{}/pebble-app.elf'.format(p)
         ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
         target=app_elf)


### PR DESCRIPTION
Adds `-fstack-usage` to the GCC compiler flags so that tools such as https://github.com/HBehrens/puncover can provide additional information about stack usage (see attached screen shots)
![127 0 0 1 5000 path users behrens documents projects pebble pebble-compass src compass_window c sort-800x100](https://cloud.githubusercontent.com/assets/486904/25310927/b61784d8-27a6-11e7-91bb-5610096661a6.png)
![127 0 0 1 5000 path users behrens documents projects pebble pebble-compass src data_provider c sched-800x800](https://cloud.githubusercontent.com/assets/486904/25310928/b62112c8-27a6-11e7-94d1-d3771dc5bcc7.png)
